### PR TITLE
fix: correct OFFSET pagination in JDBC list queries

### DIFF
--- a/src/main/java/com/tproject/workshop/repository/jdbc/impl/CustomerRepositoryJdbcImpl.java
+++ b/src/main/java/com/tproject/workshop/repository/jdbc/impl/CustomerRepositoryJdbcImpl.java
@@ -56,7 +56,7 @@ public class CustomerRepositoryJdbcImpl implements CustomerRepositoryJdbc {
                 .addValue("CPF", UtilsString.onlyDigits((filters.getCpf())), Types.VARCHAR)
                 .addValue("PHONE", filters.getPhone(), Types.VARCHAR)
                 .addValue("PAGE_SIZE", filters.getSize(), Types.INTEGER)
-                .addValue("OFFSET", filters.getPage(), Types.INTEGER);
+                .addValue("OFFSET", filters.getPage() * filters.getSize(), Types.INTEGER);
 
         List<CustomerListOutputDto> customers = jdbcTemplate.query(
                 UtilsSql.getQuery("customer/listCustomers"),

--- a/src/main/java/com/tproject/workshop/repository/jdbc/impl/DeviceRepositoryJdbcImpl.java
+++ b/src/main/java/com/tproject/workshop/repository/jdbc/impl/DeviceRepositoryJdbcImpl.java
@@ -68,7 +68,7 @@ public class DeviceRepositoryJdbcImpl implements DeviceRepositoryJdbc {
                 .addValue(ORDER_BY_FIELD, deviceParams.getOrdenation().orderByField(), Types.VARCHAR)
                 .addValue(ORDER_BY_DIRECTION, deviceParams.getOrdenation().orderByDirection().toString(), Types.VARCHAR)
                 .addValue(PAGE_SIZE, deviceParams.getSize())
-                .addValue(OFFSET, deviceParams.getPage());
+                .addValue(OFFSET, deviceParams.getPage() * deviceParams.getSize());
 
         List<DeviceTableDto> devices = jdbcTemplate
                 .query(

--- a/src/test/resources/jsons/customer-controller-i-t/searchCustomers_7.json
+++ b/src/test/resources/jsons/customer-controller-i-t/searchCustomers_7.json
@@ -1,23 +1,6 @@
 {
     "content": [
-        {
-            "id": 2,
-            "name": "Lucas Ribeiro Naga",
-            "cpf": "46203912042",
-            "email": "lucas@gmail.com",
-            "gender": "masculino",
-            "insertDate": "2023-01-06T14:41:00.968173",
-            "mainPhone": "44988255540"
-        },
-        {
-            "id": 3,
-            "name": "Maria Oliveira",
-            "cpf": "98765432100",
-            "email": "maria@gmail.com",
-            "gender": "feminino",
-            "insertDate": "2023-01-06T14:41:00.968173",
-            "mainPhone": "99988887777"
-        }
+        
     ],
     "pageable": {
         "pageNumber": 2,
@@ -28,12 +11,13 @@
             "unsorted": true
         },
         "offset": 4,
-        "unpaged": false,
-        "paged": true
+        "paged": true,
+        "unpaged": false
     },
     "last": true,
-    "totalPages": 3,
-    "totalElements": 6,
+    "totalPages": 2,
+    "totalElements": 4,
+    "first": false,
     "size": 2,
     "number": 2,
     "sort": {
@@ -41,7 +25,6 @@
         "sorted": false,
         "unsorted": true
     },
-    "first": false,
-    "numberOfElements": 2,
-    "empty": false
+    "numberOfElements": 0,
+    "empty": true
 }

--- a/src/test/resources/jsons/device-controller-i-t/searchDevices_31.json
+++ b/src/test/resources/jsons/device-controller-i-t/searchDevices_31.json
@@ -1,64 +1,6 @@
 {
     "content": [
         {
-            "deviceId": 1,
-            "customerId": 1,
-            "customerName": "Alfonso Zimmer",
-            "type": "Ventilador",
-            "brand": "Arno",
-            "model": "Model 1",
-            "status": "NOVO",
-            "problem": "Problem 1",
-            "observation": "Observation 1",
-            "hasUrgency": true,
-            "hasRevision": false,
-            "entryDate": "10/04/2023"
-        },
-        {
-            "deviceId": 14,
-            "customerId": 2,
-            "customerName": "Lucas Ribeiro Naga",
-            "type": "Ferro de passar",
-            "brand": "Philco",
-            "model": "Model 4",
-            "status": "ENTREGUE",
-            "problem": "Problem 14",
-            "observation": "Observation 14",
-            "hasUrgency": false,
-            "hasRevision": true,
-            "entryDate": "07/01/2023",
-            "departureDate": "06/01/2023"
-        },
-        {
-            "deviceId": 12,
-            "customerId": 2,
-            "customerName": "Lucas Ribeiro Naga",
-            "type": "Liquidificador",
-            "brand": "Wallita",
-            "model": "Model 2",
-            "status": "EM_ANDAMENTO",
-            "problem": "Problem 12",
-            "observation": "Observation 12",
-            "hasUrgency": false,
-            "hasRevision": true,
-            "entryDate": "06/01/2023"
-        },
-        {
-            "deviceId": 10,
-            "customerId": 2,
-            "customerName": "Lucas Ribeiro Naga",
-            "type": "Aspirador",
-            "brand": "Electrolux",
-            "model": "Model 5",
-            "status": "DESCARTADO",
-            "problem": "Problem 10",
-            "observation": "Observation 10",
-            "hasUrgency": false,
-            "hasRevision": true,
-            "entryDate": "05/01/2023",
-            "departureDate": "07/01/2023"
-        },
-        {
             "deviceId": 8,
             "customerId": 2,
             "customerName": "Lucas Ribeiro Naga",
@@ -71,6 +13,63 @@
             "hasUrgency": false,
             "hasRevision": true,
             "entryDate": "04/01/2023"
+        },
+        {
+            "deviceId": 6,
+            "customerId": 2,
+            "customerName": "Lucas Ribeiro Naga",
+            "type": "Ventilador",
+            "brand": "Arno",
+            "model": "Model 1",
+            "status": "EM_ANDAMENTO",
+            "problem": "Problem 6",
+            "observation": "Observation 6",
+            "hasUrgency": false,
+            "hasRevision": true,
+            "entryDate": "03/01/2023"
+        },
+        {
+            "deviceId": 4,
+            "customerId": 2,
+            "customerName": "Lucas Ribeiro Naga",
+            "type": "Ferro de passar",
+            "brand": "Philco",
+            "model": "Model 4",
+            "status": "ENTREGUE",
+            "problem": "Problem 4",
+            "observation": "Observation 4",
+            "hasUrgency": false,
+            "hasRevision": true,
+            "entryDate": "02/01/2023",
+            "departureDate": "05/01/2023"
+        },
+        {
+            "deviceId": 2,
+            "customerId": 2,
+            "customerName": "Lucas Ribeiro Naga",
+            "type": "Liquidificador",
+            "brand": "Wallita",
+            "model": "Model 2",
+            "status": "EM_ANDAMENTO",
+            "problem": "Problem 2",
+            "observation": "Observation 2",
+            "hasUrgency": false,
+            "hasRevision": true,
+            "entryDate": "01/01/2023"
+        },
+        {
+            "deviceId": 3,
+            "customerId": 1,
+            "customerName": "Alfonso Zimmer",
+            "type": "Batedeira",
+            "brand": "Britania",
+            "model": "Model 3",
+            "status": "AGUARDANDO",
+            "problem": "Problem 3",
+            "observation": "Observation 3",
+            "hasUrgency": true,
+            "hasRevision": false,
+            "entryDate": "03/09/2021"
         }
     ],
     "pageable": {
@@ -82,12 +81,13 @@
             "unsorted": true
         },
         "offset": 5,
-        "unpaged": false,
-        "paged": true
+        "paged": true,
+        "unpaged": false
     },
     "last": false,
-    "totalElements": 15,
     "totalPages": 3,
+    "totalElements": 15,
+    "first": false,
     "size": 5,
     "number": 1,
     "sort": {
@@ -95,7 +95,6 @@
         "sorted": false,
         "unsorted": true
     },
-    "first": false,
     "numberOfElements": 5,
     "empty": false
 }

--- a/src/test/resources/jsons/device-controller-i-t/searchDevices_32.json
+++ b/src/test/resources/jsons/device-controller-i-t/searchDevices_32.json
@@ -1,76 +1,76 @@
 {
     "content": [
         {
-            "deviceId": 14,
-            "customerId": 2,
-            "customerName": "Lucas Ribeiro Naga",
-            "type": "Ferro de passar",
-            "brand": "Philco",
-            "model": "Model 4",
-            "status": "ENTREGUE",
-            "problem": "Problem 14",
-            "observation": "Observation 14",
-            "hasUrgency": false,
-            "hasRevision": true,
-            "entryDate": "07/01/2023",
-            "departureDate": "06/01/2023"
-        },
-        {
-            "deviceId": 12,
-            "customerId": 2,
-            "customerName": "Lucas Ribeiro Naga",
-            "type": "Liquidificador",
-            "brand": "Wallita",
-            "model": "Model 2",
-            "status": "EM_ANDAMENTO",
-            "problem": "Problem 12",
-            "observation": "Observation 12",
-            "hasUrgency": false,
-            "hasRevision": true,
-            "entryDate": "06/01/2023"
-        },
-        {
-            "deviceId": 10,
-            "customerId": 2,
-            "customerName": "Lucas Ribeiro Naga",
+            "deviceId": 15,
+            "customerId": 1,
+            "customerName": "Alfonso Zimmer",
             "type": "Aspirador",
             "brand": "Electrolux",
             "model": "Model 5",
             "status": "DESCARTADO",
-            "problem": "Problem 10",
-            "observation": "Observation 10",
-            "hasUrgency": false,
-            "hasRevision": true,
-            "entryDate": "05/01/2023",
-            "departureDate": "07/01/2023"
+            "problem": "Problem 15",
+            "observation": "Observation 15",
+            "hasUrgency": true,
+            "hasRevision": false,
+            "entryDate": "22/04/2021",
+            "departureDate": "04/05/2021"
         },
         {
-            "deviceId": 8,
-            "customerId": 2,
-            "customerName": "Lucas Ribeiro Naga",
+            "deviceId": 13,
+            "customerId": 1,
+            "customerName": "Alfonso Zimmer",
             "type": "Batedeira",
             "brand": "Britania",
             "model": "Model 3",
             "status": "AGUARDANDO",
-            "problem": "Problem 8",
-            "observation": "Observation 8",
-            "hasUrgency": false,
-            "hasRevision": true,
-            "entryDate": "04/01/2023"
+            "problem": "Problem 13",
+            "observation": "Observation 13",
+            "hasUrgency": true,
+            "hasRevision": false,
+            "entryDate": "02/04/2021"
         },
         {
-            "deviceId": 6,
-            "customerId": 2,
-            "customerName": "Lucas Ribeiro Naga",
+            "deviceId": 11,
+            "customerId": 1,
+            "customerName": "Alfonso Zimmer",
             "type": "Ventilador",
             "brand": "Arno",
             "model": "Model 1",
+            "status": "NOVO",
+            "problem": "Problem 11",
+            "observation": "Observation 11",
+            "hasUrgency": true,
+            "hasRevision": false,
+            "entryDate": "01/04/2021"
+        },
+        {
+            "deviceId": 7,
+            "customerId": 1,
+            "customerName": "Alfonso Zimmer",
+            "type": "Liquidificador",
+            "brand": "Wallita",
+            "model": "Model 2",
             "status": "EM_ANDAMENTO",
-            "problem": "Problem 6",
-            "observation": "Observation 6",
-            "hasUrgency": false,
-            "hasRevision": true,
-            "entryDate": "03/01/2023"
+            "problem": "Problem 7",
+            "observation": "Observation 7",
+            "hasUrgency": true,
+            "hasRevision": false,
+            "entryDate": "10/10/2020"
+        },
+        {
+            "deviceId": 5,
+            "customerId": 1,
+            "customerName": "Alfonso Zimmer",
+            "type": "Aspirador",
+            "brand": "Electrolux",
+            "model": "Model 5",
+            "status": "DESCARTADO",
+            "problem": "Problem 5",
+            "observation": "Observation 5",
+            "hasUrgency": true,
+            "hasRevision": false,
+            "entryDate": "28/04/2017",
+            "departureDate": "28/04/2021"
         }
     ],
     "pageable": {
@@ -82,12 +82,13 @@
             "unsorted": true
         },
         "offset": 10,
-        "unpaged": false,
-        "paged": true
+        "paged": true,
+        "unpaged": false
     },
     "last": true,
-    "totalElements": 15,
     "totalPages": 3,
+    "totalElements": 15,
+    "first": false,
     "size": 5,
     "number": 2,
     "sort": {
@@ -95,7 +96,6 @@
         "sorted": false,
         "unsorted": true
     },
-    "first": false,
     "numberOfElements": 5,
     "empty": false
 }

--- a/src/test/resources/jsons/device-controller-i-t/searchDevices_34.json
+++ b/src/test/resources/jsons/device-controller-i-t/searchDevices_34.json
@@ -1,77 +1,6 @@
 {
     "content": [
-        {
-            "deviceId": 15,
-            "customerId": 1,
-            "customerName": "Alfonso Zimmer",
-            "type": "Aspirador",
-            "brand": "Electrolux",
-            "model": "Model 5",
-            "status": "DESCARTADO",
-            "problem": "Problem 15",
-            "observation": "Observation 15",
-            "hasUrgency": true,
-            "hasRevision": false,
-            "entryDate": "22/04/2021",
-            "departureDate": "04/05/2021"
-        },
-        {
-            "deviceId": 13,
-            "customerId": 1,
-            "customerName": "Alfonso Zimmer",
-            "type": "Batedeira",
-            "brand": "Britania",
-            "model": "Model 3",
-            "status": "AGUARDANDO",
-            "problem": "Problem 13",
-            "observation": "Observation 13",
-            "hasUrgency": true,
-            "hasRevision": false,
-            "entryDate": "02/04/2021"
-        },
-        {
-            "deviceId": 11,
-            "customerId": 1,
-            "customerName": "Alfonso Zimmer",
-            "type": "Ventilador",
-            "brand": "Arno",
-            "model": "Model 1",
-            "status": "NOVO",
-            "problem": "Problem 11",
-            "observation": "Observation 11",
-            "hasUrgency": true,
-            "hasRevision": false,
-            "entryDate": "01/04/2021"
-        },
-        {
-            "deviceId": 7,
-            "customerId": 1,
-            "customerName": "Alfonso Zimmer",
-            "type": "Liquidificador",
-            "brand": "Wallita",
-            "model": "Model 2",
-            "status": "EM_ANDAMENTO",
-            "problem": "Problem 7",
-            "observation": "Observation 7",
-            "hasUrgency": true,
-            "hasRevision": false,
-            "entryDate": "10/10/2020"
-        },
-        {
-            "deviceId": 5,
-            "customerId": 1,
-            "customerName": "Alfonso Zimmer",
-            "type": "Aspirador",
-            "brand": "Electrolux",
-            "model": "Model 5",
-            "status": "DESCARTADO",
-            "problem": "Problem 5",
-            "observation": "Observation 5",
-            "hasUrgency": true,
-            "hasRevision": false,
-            "entryDate": "28/04/2017",
-            "departureDate": "28/04/2021"
-        }
+        
     ],
     "pageable": {
         "pageNumber": 10,
@@ -82,12 +11,13 @@
             "unsorted": true
         },
         "offset": 50,
-        "unpaged": false,
-        "paged": true
+        "paged": true,
+        "unpaged": false
     },
     "last": true,
-    "totalElements": 55,
-    "totalPages": 11,
+    "totalPages": 3,
+    "totalElements": 15,
+    "first": false,
     "size": 5,
     "number": 10,
     "sort": {
@@ -95,7 +25,6 @@
         "sorted": false,
         "unsorted": true
     },
-    "first": false,
-    "numberOfElements": 5,
-    "empty": false
+    "numberOfElements": 0,
+    "empty": true
 }


### PR DESCRIPTION
Replace OFFSET = page with OFFSET = page * size in both DeviceRepositoryJdbcImpl and CustomerRepositoryJdbcImpl, which caused repeated IDs when scrolling past the first page.

- DeviceRepositoryJdbcImpl: addValue(OFFSET, page * size)
- CustomerRepositoryJdbcImpl: addValue(OFFSET, page * size)
- Update pagination snapshots to reflect corrected data