### PR TITLE
fix(ci): Caddy admin API healthcheck probe to curl -sf /config/

### DIFF
--- a/docker-compose-gateway.yml
+++ b/docker-compose-gateway.yml
@@ -19,7 +19,7 @@ services:
     networks:
       - workshop-ingress
     healthcheck:
-      test: ["CMD-SHELL", "wget --spider -q -O /dev/null http://127.0.0.1:2019/health || exit 1"]
+      test: ["CMD-SHELL", "curl -sf http://127.0.0.1:2019/config/ || exit 1"]
       interval: 30s
       timeout: 5s
       retries: 3


### PR DESCRIPTION
The /health endpoint is not exposed by Caddy's default Admin API
(only /load, /stop, /config/* are). Previous probe used
'wget --spider http://127.0.0.1:2019/health' which always returns
404 silently (HEAD request not supported on Admin API).

New probe: 'curl -sf http://127.0.0.1:2019/config/' returns 200
when Caddy is alive and config is loaded, achieving the same goal
of confirming Caddy responsiveness without depending on backends.

Discovered during pre-dryrun reconnaissance on release/1.3.1:
Caddy 2.9.1 in production has been running for 3 weeks without
(healthy) in 'docker ps' because the probe has always returned
404 silently.

Affects: deploy.sh, rollback.sh, verify.sh, compose healthcheck