### PR TITLE
chore(ci): add skeleton for deploy-gateway-prod workflow

### DIFF
--- a/.github/workflows/deploy-gateway-prod.yml
+++ b/.github/workflows/deploy-gateway-prod.yml
@@ -1,0 +1,45 @@
+name: Deploy Gateway (Prod) v2 (Hosted + Tailscale)
+on:
+  workflow_dispatch:
+    inputs:
+      ref:
+        description: 'Tag, branch or commit to deploy'
+        required: false
+        default: 'main'
+      confirm:
+        description: 'Production deploy confirmation'
+        type: choice
+        required: true
+        default: 'CANCEL'
+        options:
+          - DEPLOY
+          - CANCEL
+
+permissions:
+  contents: read
+
+concurrency:
+  group: deploy-gateway-prod
+  cancel-in-progress: false
+
+jobs:
+  placeholder:
+    name: Skeleton - real workflow is on release/1.3.1
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Skeleton placeholder
+        run: |
+          echo "==================================================="
+          echo "SKELETON WORKFLOW"
+          echo "==================================================="
+          echo "This is a placeholder on main to register the"
+          echo "workflow name with GitHub Actions."
+          echo ""
+          echo "The REAL workflow is on release/1.3.1."
+          echo ""
+          echo "To run the real workflow:"
+          echo "  1. Click 'Run workflow'"
+          echo "  2. In 'Use workflow from', select 'release/1.3.1'"
+          echo "  3. Fill inputs and confirm with DEPLOY"
+          echo "==================================================="
+          exit 1


### PR DESCRIPTION
## Summary

Adds a skeleton workflow `.github/workflows/deploy-gateway-prod.yml` to `main` to register the workflow name `Deploy Gateway (Prod) v2 (Hosted + Tailscale)` in GitHub Actions. The real workflow lives on `release/1.3.1`.

## Why a skeleton?

GitHub Actions requires the workflow file to exist on the default branch (`main`) for it to appear in the sidebar and be triggerable via `workflow_dispatch`. Once registered, the `Use workflow from` dropdown allows selecting `release/1.3.1` to run the real version.

## How to use

1. Go to Actions tab
2. Select `Deploy Gateway (Prod) v2 (Hosted + Tailscale)`
3. Click `Run workflow`
4. In `Use workflow from`, select `release/1.3.1`
5. Fill inputs (`ref=release/1.3.1`, `confirm=DEPLOY`) and run

## Future

This skeleton will be replaced with the real workflow when `release/1.3.1` is promoted to `main`.